### PR TITLE
Add fictive projects to footer

### DIFF
--- a/src/app/work/crm-portal/page.jsx
+++ b/src/app/work/crm-portal/page.jsx
@@ -1,0 +1,70 @@
+import PageIntro from "@/components/PageIntro";
+import Container from "@/components/Container";
+import FadeIn from "@/components/FadeIn";
+import React from "react";
+
+const CRMPortalPage = () => {
+  return (
+    <>
+      <PageIntro
+        eyebrow="Private Project"
+        title="Customer Relationship Portal"
+      >
+        <p>
+          A modern CRM platform designed to streamline customer interactions, 
+          sales processes, and marketing automation for enterprise clients.
+        </p>
+      </PageIntro>
+      
+      <Container className="mt-24 sm:mt-32 lg:mt-40">
+        <FadeIn>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-2">
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Project Overview
+              </h2>
+              <p className="mt-6 text-base text-neutral-700">
+                This comprehensive CRM portal centralizes customer data, sales 
+                pipeline management, and marketing campaigns in a unified platform. 
+                The system provides 360-degree customer views, automated lead scoring, 
+                and intelligent sales forecasting to drive business growth.
+              </p>
+              <p className="mt-4 text-base text-neutral-700">
+                Key capabilities include email marketing automation, social media 
+                integration, customer support ticket management, sales performance 
+                analytics, and seamless integration with popular business tools 
+                and third-party services.
+              </p>
+            </div>
+            
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Technology Stack
+              </h2>
+              <div className="mt-6 space-y-4">
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Frontend</h3>
+                  <p className="text-sm text-neutral-700">Next.js, React, TypeScript, Tailwind CSS</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Backend</h3>
+                  <p className="text-sm text-neutral-700">Django, Python, PostgreSQL, Celery</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">AI & Analytics</h3>
+                  <p className="text-sm text-neutral-700">TensorFlow, Scikit-learn, Pandas, NumPy</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Infrastructure</h3>
+                  <p className="text-sm text-neutral-700">Google Cloud, Firebase, Redis, Elasticsearch</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </>
+  );
+};
+
+export default CRMPortalPage;

--- a/src/app/work/dashboard-analytics/page.jsx
+++ b/src/app/work/dashboard-analytics/page.jsx
@@ -1,0 +1,68 @@
+import PageIntro from "@/components/PageIntro";
+import Container from "@/components/Container";
+import FadeIn from "@/components/FadeIn";
+import React from "react";
+
+const DashboardAnalyticsPage = () => {
+  return (
+    <>
+      <PageIntro
+        eyebrow="Private Project"
+        title="Dashboard Analytics Platform"
+      >
+        <p>
+          A comprehensive analytics dashboard designed for enterprise-level data visualization and business intelligence.
+        </p>
+      </PageIntro>
+      
+      <Container className="mt-24 sm:mt-32 lg:mt-40">
+        <FadeIn>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-2">
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Project Overview
+              </h2>
+              <p className="mt-6 text-base text-neutral-700">
+                This private analytics platform provides real-time data visualization, 
+                customizable dashboards, and advanced reporting capabilities for internal 
+                business operations. The system processes large datasets and presents 
+                insights through interactive charts and graphs.
+              </p>
+              <p className="mt-4 text-base text-neutral-700">
+                Features include user role management, automated report generation, 
+                data export functionality, and integration with various data sources 
+                including databases, APIs, and third-party services.
+              </p>
+            </div>
+            
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Technology Stack
+              </h2>
+              <div className="mt-6 space-y-4">
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Frontend</h3>
+                  <p className="text-sm text-neutral-700">React.js, TypeScript, D3.js, Chart.js, Tailwind CSS</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Backend</h3>
+                  <p className="text-sm text-neutral-700">Node.js, Express.js, PostgreSQL, Redis</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Data Processing</h3>
+                  <p className="text-sm text-neutral-700">Python, Pandas, NumPy, Apache Kafka</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Infrastructure</h3>
+                  <p className="text-sm text-neutral-700">Docker, AWS, Kubernetes, CI/CD</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </>
+  );
+};
+
+export default DashboardAnalyticsPage;

--- a/src/app/work/employee-management/page.jsx
+++ b/src/app/work/employee-management/page.jsx
@@ -1,0 +1,69 @@
+import PageIntro from "@/components/PageIntro";
+import Container from "@/components/Container";
+import FadeIn from "@/components/FadeIn";
+import React from "react";
+
+const EmployeeManagementPage = () => {
+  return (
+    <>
+      <PageIntro
+        eyebrow="Private Project"
+        title="Employee Management System"
+      >
+        <p>
+          A comprehensive HR management platform for handling employee data, payroll, 
+          performance tracking, and organizational workflows.
+        </p>
+      </PageIntro>
+      
+      <Container className="mt-24 sm:mt-32 lg:mt-40">
+        <FadeIn>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-2">
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Project Overview
+              </h2>
+              <p className="mt-6 text-base text-neutral-700">
+                This internal employee management system streamlines HR operations 
+                including employee onboarding, time tracking, leave management, 
+                performance reviews, and payroll processing. The platform ensures 
+                data security and compliance with labor regulations.
+              </p>
+              <p className="mt-4 text-base text-neutral-700">
+                Key features include automated workflow approvals, document management, 
+                reporting and analytics, integration with accounting systems, and 
+                mobile accessibility for remote work scenarios.
+              </p>
+            </div>
+            
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Technology Stack
+              </h2>
+              <div className="mt-6 space-y-4">
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Frontend</h3>
+                  <p className="text-sm text-neutral-700">Vue.js, Vuetify, PWA, Service Workers</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Backend</h3>
+                  <p className="text-sm text-neutral-700">Laravel, PHP, MySQL, Redis</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Authentication</h3>
+                  <p className="text-sm text-neutral-700">JWT, OAuth 2.0, Role-based Access Control</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Infrastructure</h3>
+                  <p className="text-sm text-neutral-700">Docker, DigitalOcean, Nginx, SSL</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </>
+  );
+};
+
+export default EmployeeManagementPage;

--- a/src/app/work/inventory-control/page.jsx
+++ b/src/app/work/inventory-control/page.jsx
@@ -1,0 +1,69 @@
+import PageIntro from "@/components/PageIntro";
+import Container from "@/components/Container";
+import FadeIn from "@/components/FadeIn";
+import React from "react";
+
+const InventoryControlPage = () => {
+  return (
+    <>
+      <PageIntro
+        eyebrow="Private Project"
+        title="Inventory Control System"
+      >
+        <p>
+          An advanced inventory management solution with real-time tracking, 
+          automated reordering, and supply chain optimization capabilities.
+        </p>
+      </PageIntro>
+      
+      <Container className="mt-24 sm:mt-32 lg:mt-40">
+        <FadeIn>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-2">
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Project Overview
+              </h2>
+              <p className="mt-6 text-base text-neutral-700">
+                This comprehensive inventory control system provides end-to-end 
+                management of stock levels, supplier relationships, and warehouse 
+                operations. The platform integrates barcode scanning, RFID technology, 
+                and predictive analytics to optimize inventory turnover and reduce costs.
+              </p>
+              <p className="mt-4 text-base text-neutral-700">
+                The system features automated demand forecasting, multi-location 
+                inventory tracking, supplier management, purchase order automation, 
+                and detailed reporting for business intelligence and compliance.
+              </p>
+            </div>
+            
+            <div>
+              <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                Technology Stack
+              </h2>
+              <div className="mt-6 space-y-4">
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Frontend</h3>
+                  <p className="text-sm text-neutral-700">Angular, Material Design, RxJS, Chart.js</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Backend</h3>
+                  <p className="text-sm text-neutral-700">Spring Boot, Java, PostgreSQL, MongoDB</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">IoT & Hardware</h3>
+                  <p className="text-sm text-neutral-700">RFID Readers, Barcode Scanners, Raspberry Pi</p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-neutral-950">Infrastructure</h3>
+                  <p className="text-sm text-neutral-700">Azure, Docker, Kubernetes, Azure IoT Hub</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </>
+  );
+};
+
+export default InventoryControlPage;

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -6,16 +6,28 @@ export const navigation = [
     title: 'Work',
     links: [
       {
-        title: 'AH MANA3RAF',
-        href : '/work/amazonclone',
+        title: 'AI-Powered E-commerce Platform',
+        href : '/work/ai-ecommerce',
       },
       {
-        title: 'AH MANA3RAF',
-        href : '/work/bazar',
+        title: 'DeFi Yield Farming Dashboard',
+        href : '/work/defi-dashboard',
       },
       {
-        title: 'AH MANA3RAF',
-        href : '/work/blog101',
+        title: 'Real-time Collaborative Editor',
+        href : '/work/collaborative-editor',
+      },
+      {
+        title: 'NFT Marketplace with Web3',
+        href : '/work/nft-marketplace',
+      },
+      {
+        title: 'Edge Computing IoT Platform',
+        href : '/work/iot-platform',
+      },
+      {
+        title: 'Metaverse Social Network',
+        href : '/work/metaverse-social',
       },
       {
         title: (

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -6,28 +6,20 @@ export const navigation = [
     title: 'Work',
     links: [
       {
-        title: 'AI-Powered E-commerce Platform',
-        href : '/work/ai-ecommerce',
+        title: 'Dashboard Analytics Platform',
+        href : '/work/dashboard-analytics',
       },
       {
-        title: 'DeFi Yield Farming Dashboard',
-        href : '/work/defi-dashboard',
+        title: 'Employee Management System',
+        href : '/work/employee-management',
       },
       {
-        title: 'Real-time Collaborative Editor',
-        href : '/work/collaborative-editor',
+        title: 'Inventory Control System',
+        href : '/work/inventory-control',
       },
       {
-        title: 'NFT Marketplace with Web3',
-        href : '/work/nft-marketplace',
-      },
-      {
-        title: 'Edge Computing IoT Platform',
-        href : '/work/iot-platform',
-      },
-      {
-        title: 'Metaverse Social Network',
-        href : '/work/metaverse-social',
+        title: 'Customer Relationship Portal',
+        href : '/work/crm-portal',
       },
       {
         title: (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add fictive private projects to the footer's 'Work' section, each linking to a dedicated detail page.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change addresses the user's request to replace generic "AH MANA3RAF" entries with more realistic, detailed, but non-publicly accessible project examples. Each project now has its own page detailing its overview and technology stack, providing a clear representation of technical capabilities without offering direct access.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-233ca5f2-d8a3-42e1-a23e-6507569b5cdf) · [Cursor](https://cursor.com/background-agent?bcId=bc-233ca5f2-d8a3-42e1-a23e-6507569b5cdf)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)